### PR TITLE
ci: remove broken `--name ${inputs.name}` support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,6 @@ jobs:
       - uses: ./
         id: starship
         with:
-          name: test-with-values
           config: config.yaml
 
       - name: Check kubectl pods
@@ -134,7 +133,6 @@ jobs:
       - uses: ./
         id: starship
         with:
-          name: test-kubeconfig
           kubeconfig: ${{ steps.kubeconfig.outputs.content }}
           config: config.yaml
 
@@ -175,7 +173,6 @@ jobs:
       - uses: ./
         id: starship
         with:
-          name: test-no-portforward
           config: config.yaml
 
       - name: Check kubectl pods

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test-with-values:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -86,6 +87,7 @@ jobs:
 
   test-with-remote-cluster:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
 
       - uses: actions/checkout@v4
@@ -151,6 +153,7 @@ jobs:
 
   test-with-no-ports:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
 
       - uses: actions/checkout@v4

--- a/action.yaml
+++ b/action.yaml
@@ -24,10 +24,6 @@ inputs:
     description: "Helm repo to fetch the chart from (default: https://hyperweb-io.github.io/starship)"
     required: false
     default: "https://hyperweb-io.github.io/starship"
-  name:
-    description: "Helm chart release name for installing helm chart"
-    required: false
-    default: "starship"
   namespace:
     description: "Kubernetes namespace to deploy helm charts on (default: ci-{github.repository}-{github.workflow}-{github.ref} )"
     required: false
@@ -41,9 +37,6 @@ outputs:
   namespace:
     description: "Kubernetes namespace to which helm charts were deployed"
     value: ${{ steps.set-namespace.outputs.namespace }}
-  name:
-    description: "Helm chart release name for installing helm chart"
-    value: ${{ inputs.name }}
 
 runs:
   using: composite
@@ -146,7 +139,6 @@ runs:
         sleep 5
         starship start \
           --config ${{ inputs.config }} \
-          --name ${{ inputs.name }} \
           --namespace ${{ steps.set-namespace.outputs.namespace }} \
           --repoUrl ${{ inputs.repo }} \
           --chart ${{ inputs.chart }} \
@@ -179,7 +171,6 @@ runs:
         kubectl get pods --namespace ${{ steps.set-namespace.outputs.namespace }}
         starship start \
           --config ${{ inputs.config }} \
-          --name ${{ inputs.name }} \
           --namespace ${{ steps.set-namespace.outputs.namespace }} \
           --repoUrl ${{ inputs.repo }} \
           --chart ${{ inputs.chart }} \
@@ -195,7 +186,6 @@ runs:
         kubectl get pods --namespace ${{ steps.set-namespace.outputs.namespace }}
         starship start \
           --config ${{ inputs.config }} \
-          --name ${{ inputs.name }} \
           --namespace ${{ steps.set-namespace.outputs.namespace }} \
           --repoUrl ${{ inputs.repo }} \
           --chart ${{ inputs.chart }} \


### PR DESCRIPTION
This PR removes support for the broken `inputs.name` support, and also removes the CI `with.name` usage that caused `starship stop` to attempt deleting a different Helm release name than the one specified in the `starship-action`'s config file.

This will allow `starship stop` to successfully delete the Helm release.  Before, it failed and waited until the Actions job timeout elapses (currently 6h, but also updated in this PR to be just 15 minutes):

```
Run starship stop --config config.yaml --namespace $NAMESPACE || true
  starship stop --config config.yaml --namespace $NAMESPACE || true
  kubectl delete namespace $NAMESPACE --wait=true
  shell: /usr/bin/bash -e {0}
  env:
    NAMESPACE: ci-hyperweb-io-starship-action-test-refs-heads-main
argv: config : config.yaml
argv: namespace : ci-hyperweb-io-starship-action-test-refs-heads-main
config again: [object Object]
Trying to stop all port-forward, if any....
helm delete osmo-wasm --namespace ci-hyperweb-io-starship-action-test-refs-heads-main
Error: uninstall: Release not loaded: osmo-wasm: release: not found
[osmosis-1-genesis-0]: Terminating, Ready: true, Restarts: 1
[wasmd-genesis-0]: Terminating, Ready: true, Restarts: 0
[osmosis-1-genesis-0]: Terminating, Ready: true, Restarts: 1
...
```